### PR TITLE
Correct 2 minor comments

### DIFF
--- a/dockerfiles/android/Dockerfile
+++ b/dockerfiles/android/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/ssh-agent:5.41.0 as ssh-agent
 
-# ca-certificates because curl will need it later on for the Maven installation
+# ca-certificates because curl uses certificates from ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends adb build-essential ca-certificates curl file git python3 python3-pip unzip
 
 # Now time to install Maven

--- a/dockerfiles/golang/Dockerfile
+++ b/dockerfiles/golang/Dockerfile
@@ -1,10 +1,10 @@
 FROM jenkins/ssh-agent:5.41.0 as ssh-agent
 
-# ca-certificates because curl will need it later on for the maven installation
+# ca-certificates because curl uses certificates from ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-# Now time to install maven
+# Now time to install golang
 ARG GOLANG_VERSION=1.22.4
 ARG TARGETARCH
 ENV ARCHITECTURE=$TARGETARCH

--- a/dockerfiles/maven/Dockerfile
+++ b/dockerfiles/maven/Dockerfile
@@ -1,6 +1,6 @@
 FROM jenkins/ssh-agent:5.41.0 as ssh-agent
 
-# ca-certificates because curl will need it later on for the maven installation
+# ca-certificates because curl uses certificates from ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/multi/Dockerfile
+++ b/dockerfiles/multi/Dockerfile
@@ -2,7 +2,7 @@ FROM jenkins/ssh-agent:5.41.0 as ssh-agent
 
 ARG NODE_MAJOR=20
 
-# ca-certificates because curl will need it later on for the Maven installation
+# ca-certificates because curl uses certificates from ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/dockerfiles/node/Dockerfile
+++ b/dockerfiles/node/Dockerfile
@@ -1,7 +1,7 @@
 FROM jenkins/ssh-agent:5.41.0 as ssh-agent
 ARG NODE_MAJOR=20
 
-# ca-certificates because curl will need it later on for the node installation
+# ca-certificates because curl uses certificates from ca-certificates
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl gnupg && \
     # Installing nodejs
     mkdir -p /etc/apt/keyrings && \


### PR DESCRIPTION
## Correct two minor comments

The golang Dockerfile is installing golang, not maven

Even in the container images where Apache Maven is not installed, the container still needs ca-certificates because curl uses it for its list of valid certificates.
