### PR TITLE
fix(plugins): Add the locale plugin

### DIFF
--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -34,6 +34,7 @@ jaxb:2.3.9-1
 jjwt-api:0.11.5-112.ve82dfb_224b_a_d
 jquery3-api:3.7.1-2
 junit:1265.v65b_14fa_f12f0
+locale:511.v212370760160
 mailer:472.vf7c289a_4b_420
 matrix-auth:3.2.2
 matrix-project:832.va_66e270d2946


### PR DESCRIPTION
## Adding Locale Plugin to Address Node Naming Issue

@uhaffner reported an issue (#394) where the word *master* appeared in the list of nodes, which was undesirable.

### Resolution
- The issue was resolved by [adding the Locale plugin](https://github.com/jenkins-docs/quickstart-tutorials/issues/394#issuecomment-2202655860).
- The [Locale plugin](https://plugins.jenkins.io/locale/) effectively addressed the naming concern.

### Proposal
Given the effectiveness of this solution, I propose we add the Locale plugin to our existing set of plugins.

### Benefits
- Resolves the node naming issue
- Provides more control over language settings
- Enhances the overall user experience

### Next Steps
1. Review this proposal
2. If approved, update the plugin list to include the Locale plugin
3. Test to ensure no conflicts with existing plugins

Your thoughts and feedback on this proposal are welcome.