### PR TITLE
fix(ga): Add GitHub Actions workflow to manually trigger Dependabot.

### DIFF
--- a/.github/workflows/run-dependabot.yml
+++ b/.github/workflows/run-dependabot.yml
@@ -1,0 +1,19 @@
+name: Run Dependabot
+
+on:
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Dependabot
+        uses: dependabot/fetch-metadata@v1
+        with:
+          package-ecosystem: "github-actions"
+          directory: "/"
+          schedule:
+            interval: "daily"


### PR DESCRIPTION
- Created a new workflow file `.github/workflows/run-dependabot.yml` to allow manual triggering of Dependabot using the `workflow_dispatch` event.
- Configured the workflow to run Dependabot for GitHub Actions updates.