### PR TITLE
fix: allow empty Docker version in updatecli pattern

### DIFF
--- a/updatecli/updatecli.d/codespaces.yaml
+++ b/updatecli/updatecli.d/codespaces.yaml
@@ -81,7 +81,7 @@ targets:
     scmid: default
     spec:
       file: .devcontainer/devcontainer.json
-      matchpattern: '("version": ")([0-9.]+)(",)'
+      matchpattern: '("version": ")([0-9.]*)(",)'
       replacepattern: '${1}{{ source "docker-version" }}${3}'
       search:
         pattern: 'ghcr\.io/devcontainers/features/docker-in-docker'


### PR DESCRIPTION
Fixes the updatecli workflow failure by allowing the pattern to match empty Docker version strings in devcontainer.json.

## Problem
The updatecli workflow was failing with:
```
ERROR: something went wrong in "target#docker-feature-version" : no line matched in file ".devcontainer/devcontainer.json" for pattern "(\"version\": \")([0-9.]+)(\",)"
```

This happened because the Docker version field in `.devcontainer/devcontainer.json` is currently empty (`"version": ""`), but the updatecli pattern required at least one digit using `[0-9.]+`.

## Solution
Changed the regex pattern from `[0-9.]+` (one or more) to `[0-9.]*` (zero or more) to match both empty strings and version numbers.

## Changes
- `updatecli/updatecli.d/codespaces.yaml`: Updated `matchpattern` for `docker-feature-version` target

## Testing
This allows updatecli to successfully match and update the Docker version field whether it's empty or contains a version number.
