### PR TITLE
fix: use file kind instead of json for devcontainer updates

### DIFF
--- a/updatecli/updatecli.d/devcontainer.yaml
+++ b/updatecli/updatecli.d/devcontainer.yaml
@@ -40,22 +40,28 @@ targets:
   dockerVersion:
     name: 'deps(devcontainer): update Docker version'
     scmid: default
-    kind: json
+    kind: file
+    sourceid: dockerLatestMinor
     spec:
       file: .devcontainer/devcontainer.json
-      key: $.features."ghcr.io/devcontainers/features/docker-in-docker:2".version
-    sourceid: dockerLatestMinor
+      matchpattern: '("version": ")([0-9.]*)(",)'
+      replacepattern: '${1}{{ source "dockerLatestMinor" }}${3}'
+      search:
+        pattern: 'ghcr\.io/devcontainers/features/docker-in-docker'
     transformers:
       - trimprefix: v
 
   githubcliVersion:
     name: 'deps(devcontainer): update GitHub CLI version'
     scmid: default
-    kind: json
+    kind: file
+    sourceid: githubcliLatestMinor
     spec:
       file: .devcontainer/devcontainer.json
-      key: $.features."ghcr.io/devcontainers/features/github-cli:1".version
-    sourceid: githubcliLatestMinor
+      matchpattern: '("version": ")([0-9.]+)(")'
+      replacepattern: '${1}{{ source "githubcliLatestMinor" }}${3}'
+      search:
+        pattern: 'ghcr\.io/devcontainers/features/github-cli'
     transformers:
       - trimprefix: v
 


### PR DESCRIPTION
Fixes the updatecli workflow failure in the weekly branch by switching from JSON path queries to file pattern matching.

## Problem
The updatecli workflow was failing with:
```
ERROR: something went wrong in "target#githubcliVersion" : could not find value for query "$.features.\"ghcr.io/devcontainers/features/github-cli:1\".version"
ERROR: something went wrong in "target#dockerVersion" : could not find value for query "$.features.\"ghcr.io/devcontainers/features/docker-in-docker:2\".version"
```

The JSON path query syntax couldn't properly handle keys containing special characters (dots, slashes, colons), even with bracket notation.

## Solution
Changed from `json` kind with JSON path queries to `file` kind with regex pattern matching:

**Before:**
```yaml
kind: json
spec:
  file: .devcontainer/devcontainer.json
  key: $.features."ghcr.io/devcontainers/features/docker-in-docker:2".version
```

**After:**
```yaml
kind: file
spec:
  file: .devcontainer/devcontainer.json
  matchpattern: '("version": ")([0-9.]*)(",)'
  replacepattern: '${1}{{ source "dockerLatestMinor" }}${3}'
  search:
    pattern: 'ghcr\.io/devcontainers/features/docker-in-docker'
```

This approach uses regex to find and update the version values, avoiding JSON path limitations with special characters.

## Changes
- `updatecli/updatecli.d/devcontainer.yaml`: Converted both `dockerVersion` and `githubcliVersion` targets from `json` kind to `file` kind

## Testing
✅ updatecli workflow now passes: https://github.com/jenkins-docs/quickstart-tutorials/actions/runs/19359860819

## Related
- #1825 - Similar fix for the main branch (different file: `codespaces.yaml`)
