### PR TITLE
fix(jenkins): resolve startup crash after upgrade to 2.555.1

### DIFF
--- a/.github/workflows/plugin_update.yml
+++ b/.github/workflows/plugin_update.yml
@@ -74,3 +74,12 @@ jobs:
               # Create pull request using gh command
               gh pr create --title "chore(jenkins): Updates Jenkins plugins" --body "This pull request updates the Jenkins plugins listed in \`plugins.txt\`." --base "$BASE_BRANCH" --head "$BRANCH_NAME"
           fi
+
+      - name: Capture Jenkins logs on failure
+        if: failure()
+        run: |
+          echo "=== Container status ==="
+          docker ps -a
+          echo "=== Jenkins controller logs ==="
+          CTRL=$(docker ps -a --format "{{.Names}}" | grep controller | head -1)
+          [ -n "$CTRL" ] && docker logs "$CTRL" 2>&1 | tail -200 || echo "No controller container found"

--- a/dockerfiles/jenkins.yaml
+++ b/dockerfiles/jenkins.yaml
@@ -13,8 +13,7 @@ jenkins:
           password: "admin"
   authorizationStrategy: loggedInUsersCanDoAnything
   crumbIssuer:
-    standard:
-      excludeClientIPFromCrumb: false
+    standard: {}
   nodes:  
   - permanent:
       labelString: "docker jenkins agent"
@@ -23,7 +22,8 @@ jenkins:
           credentialsId: "jenkins-ssh-agent-private-key"
           host: "desktop-jenkins_agent-1"
           port: 22
-          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+          sshHostKeyVerificationStrategy:
+            nonVerifyingKeyVerificationStrategy: {}
       name: "docker-ssh-jenkins-agent"
       nodeDescription: "ssh jenkins docker agent "
       remoteFS: "/home/jenkins/agent"

--- a/dockerfiles/plugins.txt
+++ b/dockerfiles/plugins.txt
@@ -16,7 +16,7 @@ credentials-binding:719.v80e905ef14eb_
 credentials:1502.v5c95e620ddfe
 display-url-api:2.217.va_6b_de84cc74b_
 durable-task:664.v2b_e7a_dfff66c
-echarts-api:6.0.0-1273.v36fc9fe89332
+echarts-api:6.0.0-1279.v4e95ca_f54783
 font-awesome-api:7.2.0-983.v3f63c34eddb_9
 git-client:6.6.0
 git:5.10.1
@@ -57,7 +57,7 @@ pipeline-stage-step:345.va_96187909426
 pipeline-stage-tags-metadata:2.2277.v00573e73ddf1
 pipeline-stage-view:2.40
 plain-credentials:199.v9f8e1f741799
-plugin-util-api:7.1320.v684dd26fca_19
+plugin-util-api:7.1330.v47b_46ee2047a_
 resource-disposer:0.25
 scm-api:728.vc30dcf7a_0df5
 script-security:1399.ve6a_66547f6e1


### PR DESCRIPTION
## Summary

Jenkins has been crashing at startup on every CI run since April 17, affecting both `plugin_update.yml` and `test-jenkins.yml`. Root cause analysis revealed three compounding issues introduced by the 2.541.3 → 2.555.1 LTS upgrade.

## Root Cause

**Primary crash**: `excludeClientIPFromCrumb` was removed from `DefaultCrumbIssuer` in newer Jenkins. Every start attempt throws:
```
io.jenkins.plugins.casc.UnknownAttributesException: standard: Invalid configuration elements for type: class hudson.security.csrf.DefaultCrumbIssuer : excludeClientIPFromCrumb
```

**Secondary issue**: `coverage:3.x` was added to `plugins.txt` but its transitive dependencies (`plugin-util-api`, `echarts-api`) were not updated to matching versions. The CI Docker builds appeared to succeed because they hit cached layers, masking the conflict.

**Missing diagnostics**: Neither workflow captured `docker logs`, making the error invisible.

## Changes

- `dockerfiles/jenkins.yaml`: Remove `excludeClientIPFromCrumb` from crumbIssuer (replaced with empty `standard: {}`)
- `dockerfiles/plugins.txt`: Bump `plugin-util-api` to `7.1330.v47b_46ee2047a_` and `echarts-api` to `6.0.0-1279.v4e95ca_f54783` to satisfy `coverage:3.x` dependencies
- `.github/workflows/plugin_update.yml`: Add `docker logs` capture step on failure

## Validation

Tested locally with Docker 29.4.0 + Docker Compose v5.1.1:
- Image builds cleanly (no dependency conflicts)
- `Jenkins is fully up and running` confirmed in logs
- Jenkins 2.555.1 responding on port 8080