### PR TITLE
fix(ci): prevent grep pipe from failing the diagnostics step

### DIFF
--- a/.github/workflows/plugin_update.yml
+++ b/.github/workflows/plugin_update.yml
@@ -81,5 +81,5 @@ jobs:
           echo "=== Container status ==="
           docker ps -a
           echo "=== Jenkins controller logs ==="
-          CTRL=$(docker ps -a --format "{{.Names}}" | grep controller | head -1)
+          CTRL=$(docker ps -a --format "{{.Names}}" | grep -m1 controller || true)
           [ -n "$CTRL" ] && docker logs "$CTRL" 2>&1 | tail -200 || echo "No controller container found"


### PR DESCRIPTION
## Summary

The failure-diagnostics step added in #2169 had a subtle bug: `grep controller | head -1` exits 1 when no matching container is found. Under bash's `-e` + `pipefail`, this aborts the step before it can print any output — the opposite of what the step is meant to do.

## Changes

- `.github/workflows/plugin_update.yml`: Replace `grep controller | head -1` with `grep -m1 controller || true` in the `Capture Jenkins logs on failure` step so the step never fails due to missing containers.

## Why it matters

This was reported on PR #2169 by the automated code reviewer. The `if: failure()` guard ensures the step only runs when something is already broken — having the diagnostic step itself fail silently would hide the root cause of the original failure.