### PR TITLE
fix(jcasc): remove deprecated excludeClientIPFromCrumb + silence release-drafter

### DIFF
--- a/.github/workflows/plugin_update.yml
+++ b/.github/workflows/plugin_update.yml
@@ -74,3 +74,12 @@ jobs:
               # Create pull request using gh command
               gh pr create --title "chore(jenkins): Updates Jenkins plugins" --body "This pull request updates the Jenkins plugins listed in \`plugins.txt\`." --base "$BASE_BRANCH" --head "$BRANCH_NAME"
           fi
+
+      - name: Capture Jenkins logs on failure
+        if: failure()
+        run: |
+          echo "=== Container status ==="
+          docker ps -a
+          echo "=== Jenkins controller logs ==="
+          CTRL=$(docker ps -a --format "{{.Names}}" | grep -m1 controller || true)
+          [ -n "$CTRL" ] && docker logs "$CTRL" 2>&1 | tail -200 || echo "No controller container found"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,17 +1,7 @@
 name: Release Drafter
 
 on:
-  push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - main
-  # pull_request event is required only for autolabeler
-  pull_request:
-    # Only following types are handled by the action, but one can default to all as well
-    types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  # pull_request_target:
-  #   types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/dockerfiles/jenkins.yaml
+++ b/dockerfiles/jenkins.yaml
@@ -13,8 +13,7 @@ jenkins:
           password: "admin"
   authorizationStrategy: loggedInUsersCanDoAnything
   crumbIssuer:
-    standard:
-      excludeClientIPFromCrumb: false
+    standard: {}
   nodes:  
   - permanent:
       labelString: "docker jenkins agent"


### PR DESCRIPTION
## Summary

Two fixes backported from `main` to the `weekly` branch.

## Changes

### 1. JCasc startup crash (`dockerfiles/jenkins.yaml`)

`DefaultCrumbIssuer` no longer accepts the `excludeClientIPFromCrumb` attribute in newer Jenkins/JCasc versions. The baked-in config caused a fatal `UnknownAttributesException` at startup, putting the controller into a restart loop.

```yaml
# Before
crumbIssuer:
  standard:
    excludeClientIPFromCrumb: false

# After
crumbIssuer:
  standard: {}
```

Note: the `plugins.txt` version bumps from the `main` fix are **not** included — the `weekly` branch uses `coverage:2.x` which does not have the plugin dependency conflict.

### 2. Failure diagnostics step (`.github/workflows/plugin_update.yml`)

Adds a `Capture Jenkins logs on failure` step so controller logs are surfaced in CI when the workflow fails. Uses `grep -m1 controller || true` to avoid aborting the step under bash `-e`/`pipefail` when no container is found.

### 3. Release Drafter silenced (`.github/workflows/release-drafter.yml`)

The action fails on every push and PR event because the repo has no releases, hitting a known pagination bug in `release-drafter`. Triggers replaced with `workflow_dispatch` only.