### PR TITLE
fix(codespaces): fix reverse proxy warning and enable CSP

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,9 @@ services:
     stdin_open: true
     tty: true
     entrypoint: sh -c "/usr/local/bin/find-name.sh"
+    environment:
+      - CODESPACE_NAME=${CODESPACE_NAME:-}
+      - GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN=${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-}
     profiles:
       - maven
       - python

--- a/dockerfiles/agent-discovery/find-name.sh
+++ b/dockerfiles/agent-discovery/find-name.sh
@@ -31,6 +31,15 @@ cat /var/jenkins_home/jenkins.yaml
 # Hopefully, Jenkins will load this JCasc configuration after we change the value
 # We will modify this file later on with the name of the agent machine, but this change has to happen as soon as possible, so Jenkins knows the token to reload the configuration later on, once we have found the agent machine name.
 
+# If running in GitHub Codespaces, update the Jenkins root URL so the reverse proxy check passes
+if [ -n "${CODESPACE_NAME:-}" ] && [ -n "${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN:-}" ]; then
+    JENKINS_URL="https://${CODESPACE_NAME}-8080.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}/"
+    export JENKINS_URL
+    yq eval -i '.unclassified.location.url = env(JENKINS_URL)' /var/jenkins_home/jenkins.yaml
+    yq eval -i '(.jenkins.disabledAdministrativeMonitors // []) as $m | .jenkins.disabledAdministrativeMonitors = ($m + ["hudson.diagnosis.ReverseProxySetupMonitor"] | unique)' /var/jenkins_home/jenkins.yaml
+    echo "✅ Codespaces detected — Jenkins URL set to: ${JENKINS_URL}"
+fi
+
 # Get the IP address of the host machine
 # The hostname -I command is used to print all network addresses of the host.
 # The awk command is used to print the first field (the first IP address).

--- a/dockerfiles/jenkins.yaml
+++ b/dockerfiles/jenkins.yaml
@@ -39,6 +39,15 @@ credentials:
               privateKey: ${readFile:/ssh-dir/jenkins_agent_ed}
           scope: SYSTEM
           username: "jenkins"
+security:
+  contentSecurityPolicy:
+    header: >-
+      sandbox allow-same-origin allow-scripts allow-popups allow-forms;
+      default-src 'self';
+      img-src 'self' data:;
+      style-src 'self' 'unsafe-inline';
+      script-src 'self' 'unsafe-inline';
+      font-src 'self';
 unclassified:
   location:
     url: "http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

Backport of #2184 to the `weekly` branch. Identical three-file change.

## Changes

### `docker-compose.yaml`
Pass `CODESPACE_NAME` and `GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN` into the `discovery_and_jcasc_modifier` container. Docker Compose forwards them transparently from the host; empty string default means no impact on local or CI runs.

### `dockerfiles/agent-discovery/find-name.sh`
When the Codespaces vars are set, update `unclassified.location.url` to the correct forwarding URL and suppress `hudson.diagnosis.ReverseProxySetupMonitor`. This runs before the final JCasc reload so the correct URL is active from first startup.

### `dockerfiles/jenkins.yaml`
Add `security.contentSecurityPolicy` with a policy that covers Jenkins' own UI requirements (inline styles/scripts) while establishing a defined CSP baseline.