### PR TITLE
fix(jcasc): use correct CspConfiguration attributes for CSP

### DIFF
--- a/dockerfiles/jenkins.yaml
+++ b/dockerfiles/jenkins.yaml
@@ -42,13 +42,7 @@ credentials:
           username: "jenkins"
 security:
   contentSecurityPolicy:
-    header: >-
-      sandbox allow-same-origin allow-scripts allow-popups allow-forms;
-      default-src 'self';
-      img-src 'self' data:;
-      style-src 'self' 'unsafe-inline';
-      script-src 'self' 'unsafe-inline';
-      font-src 'self';
+    enforce: true
 unclassified:
   location:
     url: "http://127.0.0.1:8080/"


### PR DESCRIPTION
## Problem

Jenkins crashes at startup with:

```
io.jenkins.plugins.casc.UnknownAttributesException: contentSecurityPolicy:
Invalid configuration elements for type: class jenkins.security.csp.impl.CspConfiguration : header.
Available attributes : advanced, enforce
```

The CSP block added in #2184 used `header:` which is not a valid attribute for `jenkins.security.csp.impl.CspConfiguration`.

## Fix

Replace the invalid `header` attribute with `enforce: true`, which enables CSP using Jenkins' built-in default policy and correctly silences the administrative monitor warning.