### PR TITLE
fix(jcasc): replace invalid CSP header attribute with enforce flag (weekly)

### DIFF
--- a/dockerfiles/jenkins.yaml
+++ b/dockerfiles/jenkins.yaml
@@ -41,13 +41,7 @@ credentials:
           username: "jenkins"
 security:
   contentSecurityPolicy:
-    header: >-
-      sandbox allow-same-origin allow-scripts allow-popups allow-forms;
-      default-src 'self';
-      img-src 'self' data:;
-      style-src 'self' 'unsafe-inline';
-      script-src 'self' 'unsafe-inline';
-      font-src 'self';
+    enforce: true
 unclassified:
   location:
     url: "http://127.0.0.1:8080/"


### PR DESCRIPTION
## Summary

- Fixes a crash introduced by #2185 on the `weekly` branch
- `CspConfiguration` in JCasc only accepts `advanced` and `enforce` attributes; the `header` key caused an `UnknownAttributesException` on startup, aborting the JCasc reload entirely
- Replaces the broken multi-line `header:` block with `enforce: true`

This is the `weekly` backport of the same fix already merged to `main` via #2186.

## Test plan

- [ ] Build the `simple_controller` image from this branch and confirm Jenkins starts without JCasc errors in the log
- [ ] Verify the CSP header is present in browser responses after startup