### PR TITLE
ci: use updatecli pipeline subcommand

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -29,7 +29,7 @@ jobs:
       # It uses the "diff" command of updatecli with the specified config and values files
       # The GitHub token is passed as an environment variable
       - name: Run Updatecli in Dry Run mode
-        run: updatecli diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline diff --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,6 +38,6 @@ jobs:
       # The GitHub token is passed as an environment variable
       - name: Run Updatecli in Apply mode
         if: github.ref == 'refs/heads/main'
-        run: updatecli apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
+        run: updatecli pipeline apply --config ./updatecli/updatecli.d --values ./updatecli/values.github-action.yaml
         env:
           UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The workflow calls `updatecli diff` and `updatecli apply`. Recent updatecli releases mark those top-level commands as deprecated in favour of `updatecli pipeline diff` / `updatecli pipeline apply`. They still work, it's just a warning on every run, so nothing's broken.

The `updatecli-action` step installs the latest binary with no version pin, so the `pipeline` subcommand is available. No behaviour change, it just drops the deprecation warning. I came across this updating my own repos.